### PR TITLE
add sharding to multiprocessing test

### DIFF
--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1794,12 +1794,19 @@ def _index_array(arr: Array, index: Any) -> Any:
     ],
 )
 @pytest.mark.parametrize("store", ["local"], indirect=True)
-def test_multiprocessing(store: Store, method: Literal["fork", "spawn", "forkserver"]) -> None:
+@pytest.mark.parametrize("shards", [None, (20,)])
+def test_multiprocessing(
+    store: Store, method: Literal["fork", "spawn", "forkserver"], shards: tuple[int, ...] | None
+) -> None:
     """
     Test that arrays can be pickled and indexed in child processes
     """
     data = np.arange(100)
-    arr = zarr.create_array(store=store, data=data)
+    if shards is None:
+        chunks = "auto"
+    else:
+        chunks = (1,)
+    arr = zarr.create_array(store=store, data=data, shards=shards, chunks=chunks)
     ctx = mp.get_context(method)
     with ctx.Pool() as pool:
         results = pool.starmap(_index_array, [(arr, slice(len(data)))])


### PR DESCRIPTION
Regression testing.


## Behavior on zarr<=3.1.2

```
tests/test_array.py::test_multiprocessing[None-local-fork] SKIPPED (fork not supported on Windows or OSX)                                                                                                                                       [ 16%]
tests/test_array.py::test_multiprocessing[None-local-spawn] PASSED                                                                                                                                                                              [ 33%]
tests/test_array.py::test_multiprocessing[None-local-forkserver] PASSED                                                                                                                                                                         [ 50%]
tests/test_array.py::test_multiprocessing[shards1-local-fork] SKIPPED (fork not supported on Windows or OSX)                                                                                                                                    [ 66%]
tests/test_array.py::test_multiprocessing[shards1-local-spawn] FAILED                                                                                                                                                                           [ 83%]
tests/test_array.py::test_multiprocessing[shards1-local-forkserver] FAILED                                                                                                                                                                      [100%]
```
```
=============================================================================================================== short test summary info ===============================================================================================================
SKIPPED [2] tests/test_array.py:1778: fork not supported on Windows or OSX
FAILED tests/test_array.py::test_multiprocessing[shards1-local-spawn] - assert False
FAILED tests/test_array.py::test_multiprocessing[shards1-local-forkserver] - ValueError: Stored and computed checksum do not match. Stored: b'lV\x86#'. Computed: b't\x92D\xef'.
```